### PR TITLE
Chore/add test

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,14 +1,14 @@
 echo "Deploying to gcloud..."
 
-gcloud functions deploy shawn_cat_line \
---gen2 \
---runtime=nodejs18 \
---region=asia-east1 \
---source=. \
---max-instances=3 \
---entry-point=handleRequest \
---trigger-http \
+gcloud run deploy shawn-cat-line \
+--source . \
+--function handleRequest \
+--region asia-east1 \
 --allow-unauthenticated \
---no-user-output-enabled
+--no-traffic \
+&& gcloud run services update-traffic shawn-cat-line \
+--to-latest \
+--region asia-east1
+
 
 echo "Deployed to gcloud!"

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && tsc-alias",
     "start": "functions-framework --target=handleRequest",
-    "prestart": "yarn run build",
-    "gcp-build": "yarn run build",
+    "prestart": "pnpm run build",
+    "gcp-build": "pnpm run build",
     "deploy": "sh deploy.sh",
     "test": "jest",
     "clean": "tsc --build --clean",

--- a/src/handler/line/handleText.ts
+++ b/src/handler/line/handleText.ts
@@ -45,6 +45,7 @@ const handleText = async (event: MessageEvent): Promise<Message | Message[] | nu
 					majorResults.map((major) => major.key)
 				);
 
+
 				if (!majorResults.length) return TextMessage(MessageContent.MajorNotFound);
 
 				return generateResponseMessage(parsedTerms.searchMode ?? preferenceMode ?? "cac", majorResults);
@@ -59,8 +60,8 @@ const handleText = async (event: MessageEvent): Promise<Message | Message[] | nu
 const generateResponseMessage = async (searchMode: string, results: (CacMajor | StarMajor | UacMajor)[]) => {
 	const countMessage = TextMessage(`以下是找到的校系結果`);
 
-	if (results!.length > 7) {
-		results = results!.slice(0, 7);
+	if (results.length > 7) {
+		results = results.slice(0, 7);
 	}
 
 	switch (searchMode) {

--- a/src/test/parse.test.ts
+++ b/src/test/parse.test.ts
@@ -68,3 +68,73 @@ describe("Test parseSearchTerms with no sepicfic university", () => {
 		expect(actual).toEqual(expected);
 	});
 });
+
+describe("Test parseSearchTerms with national university", () => {
+	it("should return correct search terms", async () => {
+		const test = "國立台灣大學資管";
+		const actual = await parseSearchTerms(test);
+		const expected = {
+			university: "臺灣大學",
+			universityCode: "ntu",
+			major: "資管",
+			searchMode: null,
+		};
+
+		expect(actual).toEqual(expected);
+	});
+});
+
+describe("Test parseSearchTerms with special university cases", () => {
+	it("should correctly identify 中山大學", async () => {
+		const test = "中山資管";
+		const actual = await parseSearchTerms(test);
+		const expected = {
+			university: "中山",
+			universityCode: "nsysu",
+			major: "資管",
+			searchMode: null,
+		};
+
+		expect(actual).toEqual(expected);
+	});
+
+	it("should correctly identify 中山醫學大學", async () => {
+		const test = "中山醫資管";
+		const actual = await parseSearchTerms(test);
+		const expected = {
+			university: "中山醫",
+			universityCode: "csmu",
+			major: "資管",
+			searchMode: null,
+		};
+
+		expect(actual).toEqual(expected);
+	});
+
+
+	it("should correctly identify 中山醫學大學", async () => {
+		const test = "中山醫學大學資管";
+		const actual = await parseSearchTerms(test);
+		const expected = {
+			university: "中山醫學大學",
+			universityCode: "csmu",
+			major: "資管",
+			searchMode: null,
+		};
+
+		expect(actual).toEqual(expected);
+	});
+
+	it("should correctly identify 中山醫學大學 with search mode", async () => {
+		const test = "個申中山醫資管";
+		const actual = await parseSearchTerms(test);
+		const expected = {
+			university: "中山醫",
+			universityCode: "csmu",
+			major: "資管",
+			searchMode: "cac",
+		};
+
+		expect(actual).toEqual(expected);
+	});
+});

--- a/src/test/save.test.ts
+++ b/src/test/save.test.ts
@@ -23,6 +23,7 @@ describe("Test parseSavedMajor function", () => {
 				vision: '無',
 				universities: {
 					full_name: '國立臺灣大學',
+					guide_url: 'https://www.ntu.edu.tw/files/14-1000-1000-1.pdf',
 				},
 			}
 		];
@@ -59,6 +60,7 @@ describe("Test parseSavedMajor function", () => {
 				view_count: 0,
 				universities: {
 					full_name: '國立臺灣大學',
+					guide_url: 'https://www.ntu.edu.tw/files/14-1000-1000-1.pdf',
 				},
 			  }
 		];
@@ -100,6 +102,7 @@ describe("Test parseSavedMajor function", () => {
 				view_count: 0,
 				universities: {
 					full_name: "國立臺灣大學",
+					guide_url: 'https://www.ntu.edu.tw/files/14-1000-1000-1.pdf',
 				},
 			  }
 		];

--- a/src/types/database.d.ts
+++ b/src/types/database.d.ts
@@ -6,7 +6,32 @@ export type Json =
   | { [key: string]: Json | undefined }
   | Json[]
 
-export interface Database {
+export type Database = {
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          operationName?: string
+          query?: string
+          variables?: Json
+          extensions?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
   public: {
     Tables: {
       cac_majors: {
@@ -71,10 +96,51 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "universities"
             referencedColumns: ["code"]
-          }
+          },
         ]
       }
-      chat_conversations: {
+      conversation_sessions: {
+        Row: {
+          created_at: string
+          id: string
+          is_deleted: boolean
+          major_key: string | null
+          model: string | null
+          title: string
+          updated_at: string | null
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id: string
+          is_deleted?: boolean
+          major_key?: string | null
+          model?: string | null
+          title?: string
+          updated_at?: string | null
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          is_deleted?: boolean
+          major_key?: string | null
+          model?: string | null
+          title?: string
+          updated_at?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "conversation_sessions_major_key_fkey"
+            columns: ["major_key"]
+            isOneToOne: false
+            referencedRelation: "cac_majors"
+            referencedColumns: ["key"]
+          },
+        ]
+      }
+      conversations: {
         Row: {
           content: string | null
           created_at: string
@@ -98,50 +164,12 @@ export interface Database {
         }
         Relationships: [
           {
-            foreignKeyName: "chat_conversations_session_id_fkey"
+            foreignKeyName: "conversations_session_id_fkey"
             columns: ["session_id"]
             isOneToOne: false
-            referencedRelation: "chat_sessions"
+            referencedRelation: "conversation_sessions"
             referencedColumns: ["id"]
-          }
-        ]
-      }
-      chat_sessions: {
-        Row: {
-          created_at: string
-          id: string
-          is_deleted: boolean
-          major_key: string | null
-          messages: Json[] | null
-          updated_at: string | null
-          user_id: string
-        }
-        Insert: {
-          created_at?: string
-          id: string
-          is_deleted?: boolean
-          major_key?: string | null
-          messages?: Json[] | null
-          updated_at?: string | null
-          user_id: string
-        }
-        Update: {
-          created_at?: string
-          id?: string
-          is_deleted?: boolean
-          major_key?: string | null
-          messages?: Json[] | null
-          updated_at?: string | null
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "chat_sessions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          }
+          },
         ]
       }
       customer_records: {
@@ -162,13 +190,40 @@ export interface Database {
         }
         Relationships: []
       }
+      line_profiles: {
+        Row: {
+          created_at: string
+          id: number
+          line_user_id: string
+          profile_url: string | null
+          updated_at: string | null
+          username: string | null
+        }
+        Insert: {
+          created_at?: string
+          id?: number
+          line_user_id: string
+          profile_url?: string | null
+          updated_at?: string | null
+          username?: string | null
+        }
+        Update: {
+          created_at?: string
+          id?: number
+          line_user_id?: string
+          profile_url?: string | null
+          updated_at?: string | null
+          username?: string | null
+        }
+        Relationships: []
+      }
       line_search_log: {
         Row: {
           created_at: string
           id: number
           keyword: string
           line_id: string
-          major_ids: string[] | null
+          major_keys: string[] | null
           type: string
         }
         Insert: {
@@ -176,7 +231,7 @@ export interface Database {
           id?: number
           keyword: string
           line_id: string
-          major_ids?: string[] | null
+          major_keys?: string[] | null
           type: string
         }
         Update: {
@@ -184,7 +239,7 @@ export interface Database {
           id?: number
           keyword?: string
           line_id?: string
-          major_ids?: string[] | null
+          major_keys?: string[] | null
           type?: string
         }
         Relationships: []
@@ -249,7 +304,7 @@ export interface Database {
         }
         Relationships: []
       }
-      profiles: {
+      old_profiles: {
         Row: {
           email: string | null
           id: string
@@ -268,15 +323,7 @@ export interface Database {
           identity?: number | null
           name?: string | null
         }
-        Relationships: [
-          {
-            foreignKeyName: "profiles_id_fkey"
-            columns: ["id"]
-            isOneToOne: true
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          }
-        ]
+        Relationships: []
       }
       result_test: {
         Row: {
@@ -403,7 +450,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "universities"
             referencedColumns: ["code"]
-          }
+          },
         ]
       }
       star_rules: {
@@ -480,25 +527,28 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "universities"
             referencedColumns: ["code"]
-          }
+          },
         ]
       }
       universities: {
         Row: {
           code: string
           full_name: string | null
+          guide_url: string | null
           key: string
           search_words: string
         }
         Insert: {
           code: string
           full_name?: string | null
+          guide_url?: string | null
           key: string
           search_words: string
         }
         Update: {
           code?: string
           full_name?: string | null
+          guide_url?: string | null
           key?: string
           search_words?: string
         }
@@ -560,6 +610,10 @@ export interface Database {
           user_id: string
         }
         Returns: number
+      }
+      get_user_latest_session_id: {
+        Args: Record<PropertyKey, never>
+        Returns: string
       }
       get_user_profile: {
         Args: {
@@ -714,34 +768,351 @@ export interface Database {
     }
     CompositeTypes: {
       http_header: {
-        field: string
-        value: string
+        field: string | null
+        value: string | null
       }
       http_request: {
-        method: unknown
-        uri: string
-        headers: unknown
-        content_type: string
-        content: string
+        method: unknown | null
+        uri: string | null
+        headers: Database["public"]["CompositeTypes"]["http_header"][] | null
+        content_type: string | null
+        content: string | null
       }
       http_response: {
-        status: number
-        content_type: string
-        headers: unknown
-        content: string
+        status: number | null
+        content_type: string | null
+        headers: Database["public"]["CompositeTypes"]["http_header"][] | null
+        content: string | null
       }
+    }
+  }
+  storage: {
+    Tables: {
+      buckets: {
+        Row: {
+          allowed_mime_types: string[] | null
+          avif_autodetection: boolean | null
+          created_at: string | null
+          file_size_limit: number | null
+          id: string
+          name: string
+          owner: string | null
+          owner_id: string | null
+          public: boolean | null
+          updated_at: string | null
+        }
+        Insert: {
+          allowed_mime_types?: string[] | null
+          avif_autodetection?: boolean | null
+          created_at?: string | null
+          file_size_limit?: number | null
+          id: string
+          name: string
+          owner?: string | null
+          owner_id?: string | null
+          public?: boolean | null
+          updated_at?: string | null
+        }
+        Update: {
+          allowed_mime_types?: string[] | null
+          avif_autodetection?: boolean | null
+          created_at?: string | null
+          file_size_limit?: number | null
+          id?: string
+          name?: string
+          owner?: string | null
+          owner_id?: string | null
+          public?: boolean | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
+      migrations: {
+        Row: {
+          executed_at: string | null
+          hash: string
+          id: number
+          name: string
+        }
+        Insert: {
+          executed_at?: string | null
+          hash: string
+          id: number
+          name: string
+        }
+        Update: {
+          executed_at?: string | null
+          hash?: string
+          id?: number
+          name?: string
+        }
+        Relationships: []
+      }
+      objects: {
+        Row: {
+          bucket_id: string | null
+          created_at: string | null
+          id: string
+          last_accessed_at: string | null
+          metadata: Json | null
+          name: string | null
+          owner: string | null
+          owner_id: string | null
+          path_tokens: string[] | null
+          updated_at: string | null
+          user_metadata: Json | null
+          version: string | null
+        }
+        Insert: {
+          bucket_id?: string | null
+          created_at?: string | null
+          id?: string
+          last_accessed_at?: string | null
+          metadata?: Json | null
+          name?: string | null
+          owner?: string | null
+          owner_id?: string | null
+          path_tokens?: string[] | null
+          updated_at?: string | null
+          user_metadata?: Json | null
+          version?: string | null
+        }
+        Update: {
+          bucket_id?: string | null
+          created_at?: string | null
+          id?: string
+          last_accessed_at?: string | null
+          metadata?: Json | null
+          name?: string | null
+          owner?: string | null
+          owner_id?: string | null
+          path_tokens?: string[] | null
+          updated_at?: string | null
+          user_metadata?: Json | null
+          version?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "objects_bucketId_fkey"
+            columns: ["bucket_id"]
+            isOneToOne: false
+            referencedRelation: "buckets"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      s3_multipart_uploads: {
+        Row: {
+          bucket_id: string
+          created_at: string
+          id: string
+          in_progress_size: number
+          key: string
+          owner_id: string | null
+          upload_signature: string
+          user_metadata: Json | null
+          version: string
+        }
+        Insert: {
+          bucket_id: string
+          created_at?: string
+          id: string
+          in_progress_size?: number
+          key: string
+          owner_id?: string | null
+          upload_signature: string
+          user_metadata?: Json | null
+          version: string
+        }
+        Update: {
+          bucket_id?: string
+          created_at?: string
+          id?: string
+          in_progress_size?: number
+          key?: string
+          owner_id?: string | null
+          upload_signature?: string
+          user_metadata?: Json | null
+          version?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "s3_multipart_uploads_bucket_id_fkey"
+            columns: ["bucket_id"]
+            isOneToOne: false
+            referencedRelation: "buckets"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      s3_multipart_uploads_parts: {
+        Row: {
+          bucket_id: string
+          created_at: string
+          etag: string
+          id: string
+          key: string
+          owner_id: string | null
+          part_number: number
+          size: number
+          upload_id: string
+          version: string
+        }
+        Insert: {
+          bucket_id: string
+          created_at?: string
+          etag: string
+          id?: string
+          key: string
+          owner_id?: string | null
+          part_number: number
+          size?: number
+          upload_id: string
+          version: string
+        }
+        Update: {
+          bucket_id?: string
+          created_at?: string
+          etag?: string
+          id?: string
+          key?: string
+          owner_id?: string | null
+          part_number?: number
+          size?: number
+          upload_id?: string
+          version?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "s3_multipart_uploads_parts_bucket_id_fkey"
+            columns: ["bucket_id"]
+            isOneToOne: false
+            referencedRelation: "buckets"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "s3_multipart_uploads_parts_upload_id_fkey"
+            columns: ["upload_id"]
+            isOneToOne: false
+            referencedRelation: "s3_multipart_uploads"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      can_insert_object: {
+        Args: {
+          bucketid: string
+          name: string
+          owner: string
+          metadata: Json
+        }
+        Returns: undefined
+      }
+      extension: {
+        Args: {
+          name: string
+        }
+        Returns: string
+      }
+      filename: {
+        Args: {
+          name: string
+        }
+        Returns: string
+      }
+      foldername: {
+        Args: {
+          name: string
+        }
+        Returns: string[]
+      }
+      get_size_by_bucket: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          size: number
+          bucket_id: string
+        }[]
+      }
+      list_multipart_uploads_with_delimiter: {
+        Args: {
+          bucket_id: string
+          prefix_param: string
+          delimiter_param: string
+          max_keys?: number
+          next_key_token?: string
+          next_upload_token?: string
+        }
+        Returns: {
+          key: string
+          id: string
+          created_at: string
+        }[]
+      }
+      list_objects_with_delimiter: {
+        Args: {
+          bucket_id: string
+          prefix_param: string
+          delimiter_param: string
+          max_keys?: number
+          start_after?: string
+          next_token?: string
+        }
+        Returns: {
+          name: string
+          id: string
+          metadata: Json
+          updated_at: string
+        }[]
+      }
+      operation: {
+        Args: Record<PropertyKey, never>
+        Returns: string
+      }
+      search: {
+        Args: {
+          prefix: string
+          bucketname: string
+          limits?: number
+          levels?: number
+          offsets?: number
+          search?: string
+          sortcolumn?: string
+          sortorder?: string
+        }
+        Returns: {
+          name: string
+          id: string
+          updated_at: string
+          created_at: string
+          last_accessed_at: string
+          metadata: Json
+        }[]
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
     }
   }
 }
 
+type PublicSchema = Database[Extract<keyof Database, "public">]
+
 export type Tables<
   PublicTableNameOrOptions extends
-    | keyof (Database["public"]["Tables"] & Database["public"]["Views"])
+    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
         Database[PublicTableNameOrOptions["schema"]]["Views"])
-    : never = never
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
       Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
@@ -749,67 +1120,82 @@ export type Tables<
     }
     ? R
     : never
-  : PublicTableNameOrOptions extends keyof (Database["public"]["Tables"] &
-      Database["public"]["Views"])
-  ? (Database["public"]["Tables"] &
-      Database["public"]["Views"])[PublicTableNameOrOptions] extends {
-      Row: infer R
-    }
-    ? R
+  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
+        PublicSchema["Views"])
+    ? (PublicSchema["Tables"] &
+        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
     : never
-  : never
 
 export type TablesInsert<
   PublicTableNameOrOptions extends
-    | keyof Database["public"]["Tables"]
+    | keyof PublicSchema["Tables"]
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
-    : never = never
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Insert: infer I
     }
     ? I
     : never
-  : PublicTableNameOrOptions extends keyof Database["public"]["Tables"]
-  ? Database["public"]["Tables"][PublicTableNameOrOptions] extends {
-      Insert: infer I
-    }
-    ? I
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
     : never
-  : never
 
 export type TablesUpdate<
   PublicTableNameOrOptions extends
-    | keyof Database["public"]["Tables"]
+    | keyof PublicSchema["Tables"]
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
-    : never = never
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Update: infer U
     }
     ? U
     : never
-  : PublicTableNameOrOptions extends keyof Database["public"]["Tables"]
-  ? Database["public"]["Tables"][PublicTableNameOrOptions] extends {
-      Update: infer U
-    }
-    ? U
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
     : never
-  : never
 
 export type Enums<
   PublicEnumNameOrOptions extends
-    | keyof Database["public"]["Enums"]
+    | keyof PublicSchema["Enums"]
     | { schema: keyof Database },
   EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
-    : never = never
+    : never = never,
 > = PublicEnumNameOrOptions extends { schema: keyof Database }
   ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : PublicEnumNameOrOptions extends keyof Database["public"]["Enums"]
-  ? Database["public"]["Enums"][PublicEnumNameOrOptions]
-  : never
+  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
+    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof PublicSchema["CompositeTypes"]
+    | { schema: keyof Database },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
+    ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never

--- a/src/types/major.d.ts
+++ b/src/types/major.d.ts
@@ -2,6 +2,7 @@
 type CacMajor = {
 	key: string;
 	fullName: string;
+	portfolioGuideUrl?: string | null;
 	numRecruit: string;
 	numReview: string;
 	numOutlying: string;
@@ -42,6 +43,7 @@ type BaseRawMajor = {
 	view_count: number;
 	universities: {
 		full_name: string;
+		guide_url: string | null;
 	};
   };  
 

--- a/src/utils/line/message/resultFlex.ts
+++ b/src/utils/line/message/resultFlex.ts
@@ -1,11 +1,11 @@
 import { FlexBubble, FlexMessage } from "@line/bot-sdk";
 import { CacMajor, StarMajor, UacMajor } from "@/types/major";
-import { setGoogleCalendarURL, setPortfolioURL, setUniversityTWURL } from "@/utils/setUrl";
+import { setGoogleCalendarURL, setUniversityTWURL } from "@/utils/setUrl";
 import { ColorScheme } from "@/config";
 
 export function ResultMessage(extractedResults: CacMajor[], isSaved: boolean = false): FlexMessage {
 	const bubbles: FlexBubble[] = extractedResults.map((result: CacMajor, index) => {
-		const { university, key, fullName, numRecruit, numReview, numOutlying, date, url } = result;
+		const { university, key, fullName, numRecruit, numReview, numOutlying, date, url, portfolioGuideUrl } = result;
 
 		return {
 			type: "bubble",
@@ -170,8 +170,8 @@ export function ResultMessage(extractedResults: CacMajor[], isSaved: boolean = f
 						color: ColorScheme.primary,
 						action: {
 							type: "uri",
-							label: "學習歷程參採項目",
-							uri: setPortfolioURL(fullName, key),
+							label: "審查資料準備指引",
+							uri: portfolioGuideUrl ?? "https://www.cac.edu.tw/apply114/guide.php"
 						},
 						margin: "sm",
 					},

--- a/src/utils/major/search.ts
+++ b/src/utils/major/search.ts
@@ -51,7 +51,18 @@ export async function getAllMajors(searchMode: ModeOptions, universityCode: stri
 	// then parse the csv file to get the major info
 	switch (searchMode) {
 		case "cac":{
-			const { data } = await supabase.from('cac_majors').select("*, universities(full_name)").eq('university_code', universityCode);
+			const { data } = await supabase
+				.from('cac_majors')
+				.select(`
+					*,
+					universities!inner(
+						full_name,
+						key,
+						guide_url
+					)
+				`)
+				.eq('university_code', universityCode)
+
 			return data as RawCacMajor[];
 		}
 		case "star":{
@@ -131,6 +142,7 @@ const parseCacMajorInfo = (results: RawCacMajor[]): CacMajor[] => {
 			university: r.university_code!,
 			key: r.key!,
 			fullName: r.universities.full_name! + r.full_name!,
+			portfolioGuideUrl: r.universities.guide_url,
 			numRecruit: String(r.recruit!),
 			numReview: String(r.expected_candidate!),
 			numOutlying: r.outlying!,
@@ -166,7 +178,8 @@ const parseUacMajorInfo = (results: RawUacMajor[]): UacMajor[] => {
 			referScore: r.ceec_test!,
 			englishListening: r.english_listening!,
 			url: r.redirect_url!,
-			lastYearScore: r.last_year!,
+			lastYearScore: r.last_year!.replace("_111.html", "_113.html"), // hotfix to update last year score
 		};
 	});
 };
+


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the application's university and major parsing logic, deployment process, and test coverage. The most significant changes include enhanced handling for special university name cases (such as distinguishing between "中山大學" and "中山醫學大學"), improved deployment configuration for Google Cloud Run, and the addition of new test cases to ensure correct parsing behavior. There are also updates to how guide URLs are handled and displayed in result messages.

**University and Major Parsing Improvements:**

* Enhanced the `parseSearchTerms` function to properly distinguish between "中山大學" (`nsysu`) and "中山醫學大學" (`csmu`), including nuanced handling of variations in user input and normalization of "國立" prefixes. Added a helper to determine the correct university name for "中山醫學大學" cases. (`[[1]](diffhunk://#diff-71b695100ec07ec3d5e750025f507c4cbf8439a411752d415e6168cf8ef39c45R4-R49)`, `[[2]](diffhunk://#diff-71b695100ec07ec3d5e750025f507c4cbf8439a411752d415e6168cf8ef39c45R99-R117)`)
* Updated the university extraction regex to handle optional "國立" prefixes and improved logic for extracting university names from user input. (`[src/utils/major/parse.tsR4-R49](diffhunk://#diff-71b695100ec07ec3d5e750025f507c4cbf8439a411752d415e6168cf8ef39c45R4-R49)`)

**Deployment and Build Process:**

* Migrated deployment from Google Cloud Functions to Google Cloud Run, updating the deployment script (`deploy.sh`) to use `gcloud run deploy` and manage traffic updates accordingly. (`[deploy.shL3-R12](diffhunk://#diff-30883d1df2fc62f59d66255a70dc05f60d3d4ef4d3957e6e3e38e62f6e471bd0L3-R12)`)
* Switched build and prestart scripts in `package.json` from `yarn` to `pnpm` for consistency and efficiency. (`[package.jsonL9-R10](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L9-R10)`)

**Test Coverage Enhancements:**

* Added comprehensive test cases for `parseSearchTerms`, covering scenarios with "國立" prefixes and special cases for "中山大學" and "中山醫學大學", including with and without search modes. (`[src/test/parse.test.tsR71-R140](diffhunk://#diff-c86c933cf7b07117dd86fff410dae6f34c7f171d6f44142193ef7619893611aaR71-R140)`)

**Guide URL and Result Message Improvements:**

* Updated the data fetching logic to include `guide_url` from the `universities` table in major queries, and passed this URL through to result messages for more accurate and direct guidance links. (`[[1]](diffhunk://#diff-6f923c38525d539ca94020e5af9510b55dcba5f826e8fb63007c6d4e66bd9023L54-R65)`, `[[2]](diffhunk://#diff-6f923c38525d539ca94020e5af9510b55dcba5f826e8fb63007c6d4e66bd9023R145)`)
* Modified the result message UI to display the "審查資料準備指引" button with the appropriate `portfolioGuideUrl` or a fallback URL if not present. (`[[1]](diffhunk://#diff-eb04798160113b9fdcd91eafbebbeca8ee7e2d57b826f75e26c0ad4ce2ab4327L3-R8)`, `[[2]](diffhunk://#diff-eb04798160113b9fdcd91eafbebbeca8ee7e2d57b826f75e26c0ad4ce2ab4327L173-R174)`)
* Updated test fixtures to include the new `guide_url` field for university objects. (`[[1]](diffhunk://#diff-72a0958907067acee84cc79eaa2eaa68345e5066d1a3be9ccc78f9025f2bb6baR26)`, `[[2]](diffhunk://#diff-72a0958907067acee84cc79eaa2eaa68345e5066d1a3be9ccc78f9025f2bb6baR63)`, `[[3]](diffhunk://#diff-72a0958907067acee84cc79eaa2eaa68345e5066d1a3be9ccc78f9025f2bb6baR105)`)

**Bug Fixes:**

* Fixed a bug in `generateResponseMessage` where non-null assertion was used unnecessarily, improving type safety. (`[src/handler/line/handleText.tsL62-R64](diffhunk://#diff-de27f10c7e7b2747dd983dbc7e048ddf84af73227feb104af99211ee0c0275ecL62-R64)`)
* Applied a hotfix to update the `lastYearScore` field for UAC majors by replacing outdated suffixes in URLs. (`[src/utils/major/search.tsL169-R185](diffhunk://#diff-6f923c38525d539ca94020e5af9510b55dcba5f826e8fb63007c6d4e66bd9023L169-R185)`)